### PR TITLE
Implement proper report navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,6 +33,7 @@ import { TutorialProvider } from "./context/TutorialContext";
 import AccountScreen from "./screens/AccountScreen";
 import AuthScreen from "./screens/AuthScreen";
 import GameScreen from "./screens/GameScreen";
+import ReportScreen from "./screens/ReportScreen";
 import { preloadAllData } from "./services/dataLoader";
 import { gameFlowManager } from "./services/GameFlowManager";
 import PaymentHandler from "./services/PaymentHandler";
@@ -50,6 +51,11 @@ export type RootStackParamList = {
   History: undefined;
   Auth: undefined;
   Account: undefined;
+  Report: {
+    reportData?: any; // GameReport from utils
+    source?: "current" | "history" | "daily"; // Source context
+    reportId?: string; // For history/daily reports
+  };
 };
 
 // Custom screen transition animations
@@ -383,6 +389,13 @@ function AppContent() {
                       onShowAccount={() => setShowAccount(true)}
                       onLegalPageRequest={(page) => setCurrentLegalPage(page)}
                     />
+                  </ErrorBoundary>
+                )}
+              </Stack.Screen>
+              <Stack.Screen name="Report">
+                {(props) => (
+                  <ErrorBoundary>
+                    <ReportScreen {...props} />
                   </ErrorBoundary>
                 )}
               </Stack.Screen>


### PR DESCRIPTION
- Add Report screen to navigation stack with parameters for different sources
- Auto-navigate to Report screen when games end (won/given_up)
- Update StatsModal to navigate to Report screen for historical games
- Update DailiesModal to navigate to Report screen for completed challenges
- Add New Game button to Report screen header for easy game restart
- Remove conditional report rendering from GameScreen in favor of proper navigation
- Maintain all existing functionality: graphs, definitions, achievements, sharing
- Fix linting issues and ensure clean build

Navigation flow:
- Current games: Auto-navigate to Report on completion
- History: StatsModal → Report screen → Back to modal
- Daily challenges: DailiesModal → Report screen → Back to modal
- All reports: New Game button available to start fresh