### PR TITLE
Fix UpgradePrompt header overflow issue

### DIFF
--- a/src/components/UpgradePrompt.tsx
+++ b/src/components/UpgradePrompt.tsx
@@ -303,10 +303,14 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     alignItems: "center",
     gap: 12,
+    flex: 1,
+    marginRight: 12, // Add margin to ensure space for close button
   },
   title: {
-    textAlign: "center",
+    textAlign: "left", // Change to left align since we have an icon
     fontWeight: "bold",
+    flex: 1, // Allow title to take remaining space but wrap properly
+    flexShrink: 1, // Allow title to shrink if needed
   },
   content: {
     marginBottom: 24,


### PR DESCRIPTION
- Add flex: 1 to headerLeft container to properly allocate space
- Add marginRight to ensure space for close button
- Make title flexible with proper shrinking behavior
- Change title alignment to left since it's next to icon
- Prevents title and close button from overflowing right edge