### PR TITLE
Add Open Graph image dimensions to fix Facebook preview warning

### DIFF
--- a/netlify/edge-functions/challenge-preview.ts
+++ b/netlify/edge-functions/challenge-preview.ts
@@ -91,6 +91,9 @@ export default async (request: Request, context: Context) => {
   <meta property="og:title" content="${title}">
   <meta property="og:description" content="${description}">
   <meta property="og:image" content="${previewImageUrl}">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:alt" content="${title}">
   <meta property="og:url" content="${request.url}">
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="Synapse">


### PR DESCRIPTION
- Add og:image:width and og:image:height meta tags (1200x630)
- Add og:image:alt for accessibility
- Resolves Facebook 'Inferred Property' warning about async image processing